### PR TITLE
Moved quantity calculation to its own method `calculateTotalQuantity()`

### DIFF
--- a/app/code/community/CustomGento/ConfigurableTierPrices/Helper/Data.php
+++ b/app/code/community/CustomGento/ConfigurableTierPrices/Helper/Data.php
@@ -2,11 +2,8 @@
 
 class CustomGento_ConfigurableTierPrices_Helper_Data extends Mage_Core_Helper_Abstract
 {
-
     const XML_PATH_IS_ENABLED = 'sales/customgento_configurabletierprices/is_enabled';
     const XML_PATH_DISABLED_FOR_CATEGORY = 'sales/customgento_configurabletierprices/disabled_for_category';
-
-    // attribute code length must be less than 30 symbols!
     const ATTRIBUTE_DISABLED_FOR_PRODUCT = 'configtierprices_disabled';
 
     public function isAdmin()
@@ -32,6 +29,7 @@ class CustomGento_ConfigurableTierPrices_Helper_Data extends Mage_Core_Helper_Ab
         $disabledCategories    = explode(',', Mage::getStoreConfig(self::XML_PATH_DISABLED_FOR_CATEGORY));
         $productCategories     = $product->getAvailableInCategories();
         $intersectedCategories = array_intersect($disabledCategories, $productCategories);
+
         if (!empty($intersectedCategories)) {
             return true;
         }
@@ -41,15 +39,15 @@ class CustomGento_ConfigurableTierPrices_Helper_Data extends Mage_Core_Helper_Ab
 
     public function isExtensionDisabledForProduct(Mage_Catalog_Model_Product $product)
     {
-        // get the product attribute directly, because it may not be loaded
+        // Get the product attribute directly, because it may not be loaded
         $configtierpricesDisabled = Mage::getResourceModel('catalog/product')->getAttributeRawValue(
             $product->getId(), self::ATTRIBUTE_DISABLED_FOR_PRODUCT, Mage::app()->getStore()
         );
+
         if ($configtierpricesDisabled) {
             return true;
         }
 
         return false;
     }
-
 }

--- a/app/code/community/CustomGento/ConfigurableTierPrices/Helper/Data.php
+++ b/app/code/community/CustomGento/ConfigurableTierPrices/Helper/Data.php
@@ -4,6 +4,8 @@ class CustomGento_ConfigurableTierPrices_Helper_Data extends Mage_Core_Helper_Ab
 {
     const XML_PATH_IS_ENABLED = 'sales/customgento_configurabletierprices/is_enabled';
     const XML_PATH_DISABLED_FOR_CATEGORY = 'sales/customgento_configurabletierprices/disabled_for_category';
+    
+    // attribute code length must be less than 30 symbols!
     const ATTRIBUTE_DISABLED_FOR_PRODUCT = 'configtierprices_disabled';
 
     public function isAdmin()
@@ -39,9 +41,11 @@ class CustomGento_ConfigurableTierPrices_Helper_Data extends Mage_Core_Helper_Ab
 
     public function isExtensionDisabledForProduct(Mage_Catalog_Model_Product $product)
     {
-        // Get the product attribute directly, because it may not be loaded
+        // get the product attribute directly, because it may not be loaded
         $configtierpricesDisabled = Mage::getResourceModel('catalog/product')->getAttributeRawValue(
-            $product->getId(), self::ATTRIBUTE_DISABLED_FOR_PRODUCT, Mage::app()->getStore()
+            $product->getId(),
+            self::ATTRIBUTE_DISABLED_FOR_PRODUCT,
+            Mage::app()->getStore()
         );
 
         if ($configtierpricesDisabled) {

--- a/app/code/community/CustomGento/ConfigurableTierPrices/Model/Observer.php
+++ b/app/code/community/CustomGento/ConfigurableTierPrices/Model/Observer.php
@@ -5,11 +5,11 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
     /**
      * @var CustomGento_ConfigurableTierPrices_Helper_Data
      */
-    protected $helper;
+    protected $_helper;
 
     public function __construct()
     {
-        $this->helper = Mage::helper('customgento_configurabletierprices');
+        $this->_helper = Mage::helper('customgento_configurabletierprices');
     }
 
     /**
@@ -23,27 +23,27 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
     {
         $product = $observer->getProduct();
 
-        if (!$this->helper->isExtensionEnabled() ||
-            $this->helper->isProductInDisabledCategory($product) ||
-            $this->helper->isExtensionDisabledForProduct($product)
+        if (!$this->_helper->isExtensionEnabled() ||
+            $this->_helper->isProductInDisabledCategory($product) ||
+            $this->_helper->isExtensionDisabledForProduct($product)
         ) {
             return $this;
         }
 
-        // Only apply to configurable products
+        // only apply to configurable products
         if (!$product->isConfigurable()) {
             return $this;
         }
 
-        // Do not calculate tier prices based on cart items on product page
+        // do not calculate tier prices based on cart items on product page
         // @see https://github.com/customgento/CustomGento_ConfigurableTierPrices/issues/14
         if (Mage::registry('current_product')) {
             return $this;
         }
 
-        // If tier prices are defined, also adapt them to configurable products
+        // if tier prices are defined, also adapt them to configurable products
         if ($product->getTierPriceCount() > 0) {
-            $tierPrice = $this->calculateTierPrice($product);
+            $tierPrice = $this->_calculateTierPrice($product);
             if ($tierPrice < $product->getData('final_price')) {
                 $product->setData('final_price', $tierPrice);
             }
@@ -61,9 +61,9 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
      *
      * @return  float
      */
-    protected function calculateTierPrice($product)
+    protected function _calculateTierPrice($product)
     {
-        $totalQuantity = $this->calculateTotalQuantity($product);
+        $totalQuantity = $this->_calculateTotalQuantity($product);
 
         if ($totalQuantity > 0) {
             return $product->getPriceModel()->getBasePrice($product, $totalQuantity);
@@ -79,9 +79,9 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
      *
      * @return int
      */
-    protected function calculateTotalQuantity($product)
+    protected function _calculateTotalQuantity($product)
     {
-        return array_reduce($this->getAllVisibleItems(), function ($total, $item) use ($product) {
+        return array_reduce($this->_getAllVisibleItems(), function ($total, $item) use ($product) {
             if ($item->getProductId() == $product->getId()) {
                 $total += $item->getQty();
             }
@@ -94,12 +94,12 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
      *
      * @return array with instances of Mage_Sales_Model_Quote_Item
      */
-    protected function getAllVisibleItems()
+    protected function _getAllVisibleItems()
     {
-        if ($this->helper->isAdmin()) {
+        if ($this->_helper->isAdmin()) {
             $quote = Mage::getSingleton('adminhtml/session_quote')->getQuote();
         } elseif (Mage::app()->getRequest()->getRouteName() == 'checkout') {
-            // Load the queue if we are in the checkout because otherwise the call to getQuote() will cause an
+            // load the queue if we are in the checkout because otherwise the call to getQuote() will cause an
             // infinite loop if the currency is switched
             // @see https://github.com/customgento/CustomGento_ConfigurableTierPrices/issues/24
             $quoteId = Mage::getSingleton('checkout/session')->getQuoteId();

--- a/app/code/community/CustomGento/ConfigurableTierPrices/Model/Observer.php
+++ b/app/code/community/CustomGento/ConfigurableTierPrices/Model/Observer.php
@@ -2,33 +2,48 @@
 
 class CustomGento_ConfigurableTierPrices_Model_Observer
 {
+    /**
+     * @var CustomGento_ConfigurableTierPrices_Helper_Data
+     */
+    protected $helper;
+
+    public function __construct()
+    {
+        $this->helper = Mage::helper('customgento_configurabletierprices');
+    }
 
     /**
      * Applies the tier pricing structure across different variants of configurable products.
      *
-     * @param Varien_Event_Observer $observer
+     * @param  Varien_Event_Observer $observer
      *
      * @return CustomGento_ConfigurableTierPrices_Model_Observer
      */
     public function catalogProductGetFinalPrice(Varien_Event_Observer $observer)
     {
         $product = $observer->getProduct();
-        if (!Mage::helper('customgento_configurabletierprices')->isExtensionEnabled()
-            || Mage::helper('customgento_configurabletierprices')->isProductInDisabledCategory($product)
-            || Mage::helper('customgento_configurabletierprices')->isExtensionDisabledForProduct($product)
+
+        if (!$this->helper->isExtensionEnabled() ||
+            $this->helper->isProductInDisabledCategory($product) ||
+            $this->helper->isExtensionDisabledForProduct($product)
         ) {
             return $this;
         }
 
-        // do not calculate tier prices based on cart items on product page
-        // see https://github.com/customgento/CustomGento_ConfigurableTierPrices/issues/14
-        if (Mage::registry('current_product') || !$product->isConfigurable()) {
+        // Only apply to configurable products
+        if (!$product->isConfigurable()) {
             return $this;
         }
 
-        // if tier prices are defined, also adapt them to configurable products
+        // Do not calculate tier prices based on cart items on product page
+        // @see https://github.com/customgento/CustomGento_ConfigurableTierPrices/issues/14
+        if (Mage::registry('current_product')) {
+            return $this;
+        }
+
+        // If tier prices are defined, also adapt them to configurable products
         if ($product->getTierPriceCount() > 0) {
-            $tierPrice = $this->_calcConfigProductTierPricing($product);
+            $tierPrice = $this->calculateTierPrice($product);
             if ($tierPrice < $product->getData('final_price')) {
                 $product->setData('final_price', $tierPrice);
             }
@@ -38,41 +53,40 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
     }
 
     /**
-     * Get product final price via configurable product's tier pricing structure.
-     * Uses qty of parent item to determine price.
+     * Calculate product final price via configurable product's tier pricing structure.
+     *
+     * Uses quantity of parent item to determine price.
      *
      * @param   Mage_Catalog_Model_Product $product
      *
      * @return  float
      */
-    protected function _calcConfigProductTierPricing($product)
+    protected function calculateTierPrice($product)
     {
-        $tierPrice = PHP_INT_MAX;
+        $totalQuantity = $this->calculateTotalQuantity($product);
 
-        if ($items = $this->_getAllVisibleItems()) {
-            // map mapping the IDs of the parent products with the quantities of the corresponding simple products
-            $idQuantities = array();
-            // go through all products in the quote
-            foreach ($items as $item) {
-                /** @var Mage_Sales_Model_Quote_Item $item */
-                if ($item->getParentItem()) {
-                    continue;
-                }
-
-                // this is the product ID of the parent!
-                $id = $item->getProductId();
-                // map the parent ID with the quantity of the simple product
-                $idQuantities[$id][] = $item->getQty();
-            }
-
-            // compute the total quantity of items of the configurable product
-            if (array_key_exists($product->getId(), $idQuantities)) {
-                $totalQty  = array_sum($idQuantities[$product->getId()]);
-                $tierPrice = $product->getPriceModel()->getBasePrice($product, $totalQty);
-            }
+        if ($totalQuantity > 0) {
+            return $product->getPriceModel()->getBasePrice($product, $totalQuantity);
         }
 
-        return $tierPrice;
+        return PHP_INT_MAX;
+    }
+
+    /**
+     * Calculate total quantity of product in cart.
+     *
+     * @param  Mage_Catalog_Model_Product $product
+     *
+     * @return int
+     */
+    protected function calculateTotalQuantity($product)
+    {
+        return array_reduce($this->getAllVisibleItems(), function ($total, $item) use ($product) {
+            if ($item->getProductId() == $product->getId()) {
+                $total += $item->getQty();
+            }
+            return $total;
+        });
     }
 
     /**
@@ -80,14 +94,14 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
      *
      * @return array with instances of Mage_Sales_Model_Quote_Item
      */
-    protected function _getAllVisibleItems()
+    protected function getAllVisibleItems()
     {
-        if (Mage::helper('customgento_configurabletierprices')->isAdmin()) {
+        if ($this->helper->isAdmin()) {
             $quote = Mage::getSingleton('adminhtml/session_quote')->getQuote();
-        } else if (Mage::app()->getRequest()->getRouteName() == 'checkout') {
-            // load the queue if we are in the checkout because otherwise the call to getQuote() will cause an
+        } elseif (Mage::app()->getRequest()->getRouteName() == 'checkout') {
+            // Load the queue if we are in the checkout because otherwise the call to getQuote() will cause an
             // infinite loop if the currency is switched
-            // see https://github.com/customgento/CustomGento_ConfigurableTierPrices/issues/24
+            // @see https://github.com/customgento/CustomGento_ConfigurableTierPrices/issues/24
             $quoteId = Mage::getSingleton('checkout/session')->getQuoteId();
             $quote   = Mage::getModel('sales/quote')->load($quoteId);
         } else {
@@ -96,5 +110,4 @@ class CustomGento_ConfigurableTierPrices_Model_Observer
 
         return $quote->getAllVisibleItems();
     }
-
 }

--- a/app/code/community/CustomGento/ConfigurableTierPrices/Model/System/Config/Source/Category.php
+++ b/app/code/community/CustomGento/ConfigurableTierPrices/Model/System/Config/Source/Category.php
@@ -4,7 +4,6 @@
  */
 class CustomGento_ConfigurableTierPrices_Model_System_Config_Source_Category
 {
-
     public function toOptionArray()
     {
         $collection = Mage::getResourceModel('catalog/category_collection');
@@ -33,5 +32,4 @@ class CustomGento_ConfigurableTierPrices_Model_System_Config_Source_Category
 
         return $options;
     }
-
 }


### PR DESCRIPTION
- Moved quantity calculation to its own method `calculateTotalQuantity()`
- CS fixes

@sprankhub I removed the underscores from the protected functions (PSR-2), hope this is ok for you? Personally, I hate them, but I know it's still common practice in M1... Feel free to add them again :)
